### PR TITLE
[fix] ストーリークラスのリファクタリング（会話文）

### DIFF
--- a/Assets/Script/Game/Story.meta
+++ b/Assets/Script/Game/Story.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4e5aa3ea8baae643853a54e25e12cd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Game/Story/Story.cs
+++ b/Assets/Script/Game/Story/Story.cs
@@ -1,0 +1,42 @@
+using TMPro;
+using UnityEngine;
+
+/// <summary>ストーリーイベントを実行するクラス</summary>
+public class Story : MonoBehaviour
+{
+    /// <summary>会話文</summary>
+    string[,] _message = new string[4,2]
+    {
+        // ストーリー1
+        {"グランマ\nはじめまして", 
+         "グランマ\nおいしいクッキーを焼いてあげるよ"},
+        // ストーリー2
+        {"グランマ\nこんなブラック環境は初めてだよ", 
+         "グランマ\nもうクッキー焼きたくないよ"}, 
+        // ストーリー3
+        {"あなた\nもうババアは笑ってくれない...", 
+         "あなた\n過去に戻ってやり直すべきか...?"}, 
+        // ストーリー4
+        {"あなた\nどうしてこうなったんだ...", 
+         "あなた\nもう何もかも終わりだ..."}
+    };
+
+    /// <summary>会話文を表示するテキスト</summary>
+    [Header("会話文を表示するテキスト")]
+    [SerializeField] TextMeshProUGUI _messageText;
+    void Start()
+    {
+        
+    }
+
+    void Update()
+    {
+        
+    }
+
+    /// <summary>会話文を更新する。画面をクリックする度に呼ばれる。</summary>
+    public void UpdateMessageText()
+    {
+
+    }
+}

--- a/Assets/Script/Game/Story/Story.cs.meta
+++ b/Assets/Script/Game/Story/Story.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 393d6f6d17e1725499a090eebd1c84da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
現在のストーリーイベントは、各ストーリーのプレハブをイベントの際にそれぞれ有効化して実装している。
これを、1つのオブジェクトのみに絞り、会話の内容などをスクリプトから変更することで、より拡張しやすい実装にしたい。

（今回）
・各プレハブから指定していた会話文をスクリプトでまとめて管理するように変更。